### PR TITLE
Make conversion of RevisionType explicit to avoid failure using Npgsql

### DIFF
--- a/Src/NHibernate.Envers/Entities/RevisionTypeType.cs
+++ b/Src/NHibernate.Envers/Entities/RevisionTypeType.cs
@@ -30,7 +30,7 @@ namespace NHibernate.Envers.Entities
 			} 
 			else 
 			{
-				cmd.Parameters[index].Value = value;
+				cmd.Parameters[index].Value = Convert.ToByte(value);
 			}
 		}
 


### PR DESCRIPTION
This failure was mentioned by somebody else on the mailing list. Our internal tests prove that this trivial change eliminates the exception.