### PR TITLE
Fix invalid cast exception when column is Formula Type

### DIFF
--- a/Src/NHibernate.Envers/Configuration/Metadata/MetadataTools.cs
+++ b/Src/NHibernate.Envers/Configuration/Metadata/MetadataTools.cs
@@ -313,7 +313,7 @@ namespace NHibernate.Envers.Configuration.Metadata
 
 		public static IEnumerable<string> GetColumnNameEnumerator(IEnumerable<ISelectable> columns)
 		{
-			return (from Column column in columns select column.Name);
+			return columns.OfType<Column>().Select(x => x.Name);
 		}
 
 		public static void AddModifiedFlagProperty(XElement parent, string propertyName, string suffix)


### PR DESCRIPTION
When you have a Formula property in your mapping, Envers throws an invalid cast exception in GetColumnNameEnumerator from Envers.Configuration.Metadta.MetadataTools