### PR TITLE
Test for incorrect audit table insert on tables with tree structure

### DIFF
--- a/Src/NHibernate.Envers.Tests/NetSpecific/Integration/Tree/Mapping.hbm.xml
+++ b/Src/NHibernate.Envers.Tests/NetSpecific/Integration/Tree/Mapping.hbm.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<hibernate-mapping xmlns="urn:nhibernate-mapping-2.2"
+                   assembly="NHibernate.Envers.Tests"
+                   namespace="NHibernate.Envers.Tests.NetSpecific.Integration.Tree">
+    <class name="TreeEntity">
+        <id name="Id">
+            <generator class="native"/>
+        </id>
+        <property name="Name" not-null="true"/>
+        <many-to-one name="Parent" class="TreeEntity" column="parentKey"/>
+        <list name="Children" cascade="all-delete-orphan">
+            <key column="parentKey"/>
+            <index column="parentInd"/>
+            <one-to-many class="TreeEntity"/>
+        </list>
+    </class>
+</hibernate-mapping>

--- a/Src/NHibernate.Envers.Tests/NetSpecific/Integration/Tree/TreeEntity.cs
+++ b/Src/NHibernate.Envers.Tests/NetSpecific/Integration/Tree/TreeEntity.cs
@@ -1,0 +1,26 @@
+using System.Collections.Generic;
+using NHibernate.Envers.Configuration.Attributes;
+
+namespace NHibernate.Envers.Tests.NetSpecific.Integration.Tree
+{
+	[Audited]
+	public class TreeEntity
+	{
+		public virtual long Id { get; set; }
+		public virtual string Name { get; set; }
+		public virtual TreeEntity Parent { get; set; }
+		public virtual IList<TreeEntity> Children { get; protected set; } = new List<TreeEntity>();
+		
+		public override bool Equals(object obj)
+		{
+			if (!(obj is TreeEntity other))
+				return false;
+			return Id == other.Id;
+		}
+
+		public override int GetHashCode()
+		{
+			return Id.GetHashCode();
+		}
+	}
+}

--- a/Src/NHibernate.Envers.Tests/NetSpecific/Integration/Tree/TreeTest.cs
+++ b/Src/NHibernate.Envers.Tests/NetSpecific/Integration/Tree/TreeTest.cs
@@ -1,0 +1,57 @@
+using System.Collections.Generic;
+using NUnit.Framework;
+
+namespace NHibernate.Envers.Tests.NetSpecific.Integration.Tree
+{
+	public class TreeTest : TestBase
+	{
+		private long parentId;
+		private long childId;
+
+		public TreeTest(AuditStrategyForTest strategyType) : base(strategyType)
+		{
+		}
+
+		protected override IEnumerable<string> Mappings => new[] {"NetSpecific.Integration.Tree.Mapping.hbm.xml"};
+
+		protected override void Initialize()
+		{
+			var parent = new TreeEntity {Name = "Parent"};
+
+			using (var tx = Session.BeginTransaction())
+			{
+				parentId = (long) Session.Save(parent);
+				tx.Commit();
+			}
+
+			var child = new TreeEntity
+			{
+				Name = "Child",
+				Parent = new TreeEntity {Id = parentId}
+			};
+
+			using (var tx = Session.BeginTransaction())
+			{
+				childId = (long) Session.Save(child);
+				tx.Commit();
+			}
+		}
+
+		[Test]
+		public void VerifyRevisionCount()
+		{
+			CollectionAssert.AreEquivalent(new[] {1}, AuditReader().GetRevisions(typeof(TreeEntity), parentId));
+			CollectionAssert.AreEquivalent(new[] {2}, AuditReader().GetRevisions(typeof(TreeEntity), childId));
+		}
+
+		[Test]
+		public void VerifyHistory()
+		{
+			var rev1 = AuditReader().Find<TreeEntity>(parentId, 1);
+			var rev2 = AuditReader().Find<TreeEntity>(parentId, 2);
+
+			Assert.IsNotNull(rev1.Name);
+			Assert.IsNotNull(rev2.Name);
+		}
+	}
+}


### PR DESCRIPTION
As requested in Issue #18 I have made a test for this example.