### PR TITLE
Using BestGuessEntityName since nhibernate is failing with `null` to …

### DIFF
--- a/Src/NHibernate.Envers/Tools/Toolz.cs
+++ b/Src/NHibernate.Envers/Tools/Toolz.cs
@@ -23,7 +23,7 @@ namespace NHibernate.Envers.Tools
 				? null
 				: (obj is INHibernateProxy objAsProxy
 					? objAsProxy.HibernateLazyInitializer.Identifier
-					: session.GetEntityPersister(null, obj).GetIdentifier(obj));
+					: session.GetEntityPersister(session.BestGuessEntityName(obj), obj).GetIdentifier(obj));
 		}
 
 		public static object GetTargetFromProxy(ISessionImplementor session, INHibernateProxy proxy) 


### PR DESCRIPTION
Using BestGuessEntityName since nhibernate is failing with `null` to retrieve entity nema when it is a *FieldProxyInterceptor