### PR TITLE
Fix for NullReferenceException in lazy bidirectional many-to-one properties

### DIFF
--- a/Src/NHibernate.Envers.Tests/NetSpecific/Integration/ManyToOne/LazyProperty/Bidirectional/Car.cs
+++ b/Src/NHibernate.Envers.Tests/NetSpecific/Integration/ManyToOne/LazyProperty/Bidirectional/Car.cs
@@ -1,0 +1,12 @@
+﻿using NHibernate.Envers.Configuration.Attributes;
+
+namespace NHibernate.Envers.Tests.NetSpecific.Integration.ManyToOne.LazyProperty.Bidirectional
+{
+	[Audited]
+	public class Car
+	{
+		public virtual long Id { get; set; }
+		public virtual int Number { get; set; }
+		public virtual Person Owner { get; set; }
+	}
+}

--- a/Src/NHibernate.Envers.Tests/NetSpecific/Integration/ManyToOne/LazyProperty/Bidirectional/LazyPropertyTest.cs
+++ b/Src/NHibernate.Envers.Tests/NetSpecific/Integration/ManyToOne/LazyProperty/Bidirectional/LazyPropertyTest.cs
@@ -1,0 +1,46 @@
+﻿using System.Linq;
+using NUnit.Framework;
+using SharpTestsEx;
+
+namespace NHibernate.Envers.Tests.NetSpecific.Integration.ManyToOne.LazyProperty.Bidirectional
+{
+	public partial class LazyPropertyBidirectionalTest : TestBase
+	{
+		private long id_pers1;
+
+		public LazyPropertyBidirectionalTest(AuditStrategyForTest strategyType) : base(strategyType)
+		{
+		}
+
+		protected override void Initialize()
+		{
+			var pers1 = new Person {Name = "Hernan"};
+
+			using (var tx = Session.BeginTransaction())
+			{
+				id_pers1 = (long) Session.Save(pers1);
+				tx.Commit();
+			}
+		}
+
+		[Test]
+		public void SavePersonProxyForFieldInterceptor()
+		{
+			long carId;
+			using (var tx = Session.BeginTransaction())
+			{
+				var pers = Session.Query<Person>().Single(x => x.Id == id_pers1);
+				var car = new Car
+				{
+					Owner = pers
+				};
+				pers.Cars.Add(car);
+				carId = (long) Session.Save(car);
+				tx.Commit();
+			}
+
+			AuditReader().Find<Car>(carId, 2).Owner.Name
+				.Should().Be.EqualTo("Hernan");
+		}
+	}
+}

--- a/Src/NHibernate.Envers.Tests/NetSpecific/Integration/ManyToOne/LazyProperty/Bidirectional/Mapping.hbm.xml
+++ b/Src/NHibernate.Envers.Tests/NetSpecific/Integration/ManyToOne/LazyProperty/Bidirectional/Mapping.hbm.xml
@@ -1,0 +1,24 @@
+﻿<hibernate-mapping xmlns="urn:nhibernate-mapping-2.2"
+                   assembly="NHibernate.Envers.Tests"
+                   namespace="NHibernate.Envers.Tests.NetSpecific.Integration.ManyToOne.LazyProperty.Bidirectional">
+    <class name="Person" table="DRIVERS">
+        <id name="Id" column="ID_PERSON" type="long">
+            <generator class="native"/>
+        </id>
+        <property name="Name" type="string" length="255"
+                  column="NAME" not-null="true" lazy="true"/>
+
+		<set name="Cars" inverse="true" cascade="none">
+			<key column="person_id" />
+			<one-to-many class="Car" />
+		</set>
+	</class>
+
+    <class name="Car">
+        <id name="Id" column="ID_CAR" type="long">
+            <generator class="native"/>
+        </id>
+        <property name="Number" type="int" not-null="true" column="numb"/>
+        <many-to-one name="Owner" class="Person" column="person_id"/>
+    </class>
+</hibernate-mapping>

--- a/Src/NHibernate.Envers.Tests/NetSpecific/Integration/ManyToOne/LazyProperty/Bidirectional/Person.cs
+++ b/Src/NHibernate.Envers.Tests/NetSpecific/Integration/ManyToOne/LazyProperty/Bidirectional/Person.cs
@@ -1,0 +1,13 @@
+﻿using NHibernate.Envers.Configuration.Attributes;
+using System.Collections.Generic;
+
+namespace NHibernate.Envers.Tests.NetSpecific.Integration.ManyToOne.LazyProperty.Bidirectional
+{
+	[Audited]
+	public class Person
+	{
+		public virtual long Id { get; set; }
+		public virtual string Name { get; set; }
+		public virtual ISet<Car> Cars { get; set; }
+	}
+}

--- a/Src/NHibernate.Envers/Event/AuditEventListener.cs
+++ b/Src/NHibernate.Envers/Event/AuditEventListener.cs
@@ -81,20 +81,17 @@ namespace NHibernate.Envers.Event
 		{
 			// relDesc.getToEntityName() doesn't always return the entity name of the value - in case
 			// of subclasses, this will be root class, no the actual class. So it can't be used here.
-			string toEntityName;
 			object id;
 
+			var toEntityName = session.BestGuessEntityName(value);
 			if (value is INHibernateProxy newValueAsProxy)
 			{
-				toEntityName = session.BestGuessEntityName(value);
 				id = newValueAsProxy.HibernateLazyInitializer.Identifier;
 				// We've got to initialize the object from the proxy to later read its state.
 				value = Toolz.GetTargetFromProxy(session, newValueAsProxy);
 			}
 			else
 			{
-				toEntityName = session.GuessEntityName(value);
-
 				var idMapper = VerCfg.EntCfg[toEntityName].IdMapper;
 				id = idMapper.MapToIdFromEntity(value);
 			}


### PR DESCRIPTION
Having a many-to-one bidirectional mapping with lazy properties will result in a `NullReferenceException` in `AuditEventListener`. This change to the `AuditEventListener` will fix this. There is also an accompanying unit test for this.

The underlying problem that triggered the `NullReferenceException` was due to the fact that the entity name could not be resolved since it was not of the expected type. The type in the case of a lazy property is a `<entity name>ProxyForFieldInterceptor` and not the actual type of the entity. Using the NHibernate utility method `BestGuessEntityName` will resolve to the actual entity name thus satisfying the mapping in Envers.

As I am not familiar to the Envers code base I tried to keep the `AuditEventListener` changes minimal not to disturb the functionality. All tests passes and this fixes the problem but I'm not totally sure how the mapping actually works and the `value` argument is still of the `ProxyForFieldInterceptor` type. Could this be a problem?   